### PR TITLE
🧹 Expand use of shared tag normalization

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -178,7 +178,13 @@ saveSnippetBtn.addEventListener("click", async () => {
 
   const tagsArray = [];
   if (tagName) {
-    tagsArray.push({ name: tagName, category: tagCategory || "general" });
+    const normalized = domain.normalizeTag ? domain.normalizeTag({ name: tagName, category: tagCategory }) : null;
+    if (normalized) {
+      tagsArray.push(normalized);
+    } else {
+      // Fallback if domain.normalizeTag is not available or returned null
+      tagsArray.push({ name: tagName, category: tagCategory || "general" });
+    }
   }
 
   const newSnippet = {
@@ -491,7 +497,8 @@ function createSnippetTags(snippet) {
   tags.forEach((tag) => {
     const tagEl = document.createElement("span");
     tagEl.className = "tag";
-    tagEl.textContent = `${tag.name} (${tag.category || "general"})`;
+    const category = tag.category || "general";
+    tagEl.textContent = `${tag.name} (${category})`;
     tagContainer.appendChild(tagEl);
   });
   return tagContainer;
@@ -610,7 +617,16 @@ function createEditForm(snippet) {
     const nextTagName = editTagNameInput.value.trim();
     const nextTagCategory = editTagCategoryInput.value.trim();
     const otherTags = domain.getSnippetTags(snippet).slice(1);
-    const firstTag = nextTagName ? [{ name: nextTagName, category: nextTagCategory || "general" }] : [];
+
+    let firstTag = [];
+    if (nextTagName) {
+      const normalized = domain.normalizeTag ? domain.normalizeTag({ name: nextTagName, category: nextTagCategory }) : null;
+      if (normalized) {
+        firstTag = [normalized];
+      } else {
+        firstTag = [{ name: nextTagName, category: nextTagCategory || "general" }];
+      }
+    }
     const nextTags = [...firstTag, ...otherTags];
 
     const updatedSnippet = {

--- a/snippet-domain.js
+++ b/snippet-domain.js
@@ -3,6 +3,11 @@
  * This file intentionally avoids DOM/chrome APIs so it can be unit tested.
  */
 
+let utils;
+if (typeof require !== "undefined") {
+  utils = require("./utils.js");
+}
+
 function getSnippetTags(snippet) {
   return Array.isArray(snippet?.tags) ? snippet.tags : [];
 }
@@ -11,32 +16,25 @@ function ensureSnippetsArray(snippets) {
   return Array.isArray(snippets) ? snippets : [];
 }
 
-function normalizeTag(tag) {
-  if (!tag || typeof tag !== "object") return null;
-  const name = typeof tag.name === "string" ? tag.name.trim() : "";
-  if (!name) return null;
-  const rawCategory = typeof tag.category === "string" ? tag.category.trim() : "";
-  const category = rawCategory || "general";
-  const key = `${name.toLowerCase()}:${category.toLowerCase()}`;
-  return { name, category, key };
+function internalNormalizeTag(tag) {
+  if (typeof utils !== "undefined" && utils.normalizeTag) {
+    return utils.normalizeTag(tag);
+  }
+  if (typeof normalizeTag === "function") {
+    return normalizeTag(tag);
+  }
+  return null;
 }
 
 function isValidImportedTag(tag) {
-  return !!tag &&
-    typeof tag === "object" &&
-    typeof tag.name === "string" &&
-    tag.name.trim().length > 0 &&
-    (tag.category === undefined || typeof tag.category === "string");
+  return !!internalNormalizeTag(tag);
 }
 
 function normalizeSnippetTags(tags) {
   if (!Array.isArray(tags)) return [];
   return tags
-    .filter(isValidImportedTag)
-    .map((tag) => ({
-      ...tag,
-      category: tag.category && tag.category.trim().length > 0 ? tag.category : "general"
-    }));
+    .map(internalNormalizeTag)
+    .filter((tag) => !!tag);
 }
 
 function isValidImportedSnippet(snippet) {
@@ -67,14 +65,9 @@ function buildTagFilterOptions(snippets) {
   ensureSnippetsArray(snippets).forEach((snippet) => {
     const tags = getSnippetTags(snippet);
     tags.forEach((tag) => {
-      if (!tag || typeof tag !== "object") return;
-      const name = typeof tag.name === "string" ? tag.name.trim() : "";
-      if (!name) return;
-      const rawCategory = typeof tag.category === "string" ? tag.category.trim() : "";
-      const category = rawCategory || "general";
-      const key = `${name.toLowerCase()}:${category.toLowerCase()}`;
-      if (!tagsMap.has(key)) {
-        tagsMap.set(key, `${name} (${category})`);
+      const normalized = internalNormalizeTag(tag);
+      if (normalized && !tagsMap.has(normalized.key)) {
+        tagsMap.set(normalized.key, `${normalized.name} (${normalized.category})`);
       }
     });
   });
@@ -91,7 +84,7 @@ function parseTagSelection(selectedTag) {
   const lastColonIndex = selectedTag.lastIndexOf(":");
   const name = lastColonIndex > -1 ? selectedTag.substring(0, lastColonIndex) : selectedTag;
   const category = lastColonIndex > -1 ? selectedTag.substring(lastColonIndex + 1) : "";
-  return normalizeTag({ name, category });
+  return internalNormalizeTag({ name, category });
 }
 
 function includesSearchText(snippet, searchTerm) {
@@ -100,13 +93,10 @@ function includesSearchText(snippet, searchTerm) {
   const inTitle = title.toLowerCase().includes(searchTerm);
   const inContent = content.toLowerCase().includes(searchTerm);
   const inTags = getSnippetTags(snippet).some((tag) => {
-    if (!tag || typeof tag !== "object") return false;
-    const name = typeof tag.name === "string" ? tag.name.trim() : "";
-    if (!name) return false;
-    if (name.toLowerCase().includes(searchTerm)) return true;
-    const rawCategory = typeof tag.category === "string" ? tag.category.trim() : "";
-    const category = rawCategory || "general";
-    return category.toLowerCase().includes(searchTerm);
+    const normalized = internalNormalizeTag(tag);
+    if (!normalized) return false;
+    return normalized.name.toLowerCase().includes(searchTerm) ||
+      normalized.category.toLowerCase().includes(searchTerm);
   });
   return inTitle || inContent || inTags;
 }
@@ -117,8 +107,6 @@ function filterSnippets(snippets, options = {}) {
   const selectedTag = typeof options.selectedTag === "string" ? options.selectedTag : "";
 
   const parsedTag = parseTagSelection(selectedTag);
-  const selectedNameLower = parsedTag ? parsedTag.name.toLowerCase() : "";
-  const selectedCategoryLower = parsedTag ? parsedTag.category.toLowerCase() : "";
 
   return ensureSnippetsArray(snippets).filter((snippet) => {
     if (!snippet || typeof snippet !== "object") {
@@ -131,13 +119,8 @@ function filterSnippets(snippets, options = {}) {
 
     if (parsedTag) {
       const hasTag = getSnippetTags(snippet).some((tag) => {
-        if (!tag || typeof tag !== "object") return false;
-        const name = typeof tag.name === "string" ? tag.name.trim() : "";
-        if (!name) return false;
-        const rawCategory = typeof tag.category === "string" ? tag.category.trim() : "";
-        const category = rawCategory || "general";
-        return name.toLowerCase() === selectedNameLower &&
-          category.toLowerCase() === selectedCategoryLower;
+        const normalized = internalNormalizeTag(tag);
+        return normalized && normalized.key === parsedTag.key;
       });
       if (!hasTag) return false;
     }
@@ -250,7 +233,8 @@ const snippetDomain = {
   buildTagFilterOptions,
   filterSnippets,
   sortSnippets,
-  mergeImportedSnippets
+  mergeImportedSnippets,
+  normalizeTag: internalNormalizeTag
 };
 
 if (typeof window !== "undefined") {

--- a/snippet-domain.test.js
+++ b/snippet-domain.test.js
@@ -52,7 +52,7 @@ test("normalizeImportedSnippet applies defaults and preserves extra fields", () 
 
   assert.strictEqual(normalized.updatedAt, 100);
   assert.strictEqual(normalized.favorite, false);
-  assert.deepStrictEqual(normalized.tags, [{ name: "work", category: "general" }]);
+  assert.deepStrictEqual(normalized.tags, [{ name: "work", category: "general", key: "work:general" }]);
   assert.deepStrictEqual(normalized.extra, { keep: true });
 });
 

--- a/utils.js
+++ b/utils.js
@@ -43,12 +43,11 @@ function mergeSnippets(a, b, updatedAt = Date.now()) {
   const tags = [...tagsA, ...tagsB];
   const seen = new Set();
   const uniqTags = tags
-    .map((tag) => normalizeTagForMerge(tag))
+    .map((tag) => normalizeTag(tag))
     .filter((tag) => !!tag)
     .filter((tag) => {
-      const key = `${tag.name.toLowerCase()}|${tag.category.toLowerCase()}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
+      if (seen.has(tag.key)) return false;
+      seen.add(tag.key);
       return true;
     });
 
@@ -65,21 +64,36 @@ function mergeSnippets(a, b, updatedAt = Date.now()) {
   };
 }
 
-function normalizeTagForMerge(tag) {
+/**
+ * Normalize a tag object.
+ * Returns null if the tag is invalid (missing name).
+ * Otherwise returns a new object with trimmed name, category (default 'general'),
+ * and a lookup key 'name:category' in lowercase.
+ * Preserves other properties of the tag object.
+ */
+function normalizeTag(tag) {
   if (!tag || typeof tag !== "object") return null;
   const name = typeof tag.name === "string" ? tag.name.trim() : "";
   if (!name) return null;
   const rawCategory = typeof tag.category === "string" ? tag.category.trim() : "";
+  const category = rawCategory || "general";
+  const key = `${name.toLowerCase()}:${category.toLowerCase()}`;
   return {
     ...tag,
     name,
-    category: rawCategory || "general"
+    category,
+    key
   };
+}
+
+function normalizeTagForMerge(tag) {
+  return normalizeTag(tag);
 }
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     generateId,
-    mergeSnippets
+    mergeSnippets,
+    normalizeTag
   };
 }

--- a/utils.test.js
+++ b/utils.test.js
@@ -1,6 +1,31 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { generateId, mergeSnippets } = require('./utils.js');
+const { generateId, mergeSnippets, normalizeTag } = require('./utils.js');
+
+test('normalizeTag normalizes valid tag and returns null for invalid', () => {
+  assert.deepStrictEqual(normalizeTag({ name: " Work ", category: " " }), {
+    name: "Work",
+    category: "general",
+    key: "work:general"
+  });
+
+  assert.deepStrictEqual(normalizeTag({ name: "tag" }), {
+    name: "tag",
+    category: "general",
+    key: "tag:general"
+  });
+
+  assert.deepStrictEqual(normalizeTag({ name: "tag", category: "CAT", extra: 1 }), {
+    name: "tag",
+    category: "CAT",
+    key: "tag:cat",
+    extra: 1
+  });
+
+  assert.strictEqual(normalizeTag(null), null);
+  assert.strictEqual(normalizeTag({}), null);
+  assert.strictEqual(normalizeTag({ name: "  " }), null);
+});
 
 test('generateId format', () => {
   const id = generateId();
@@ -173,8 +198,8 @@ test('mergeSnippets normalizes tags and drops invalid tag entries', () => {
   );
 
   assert.deepStrictEqual(merged.tags, [
-    { name: 'Work', category: 'general' },
-    { name: 'Meet', category: 'Team' }
+    { name: 'Work', category: 'general', key: 'work:general' },
+    { name: 'Meet', category: 'Team', key: 'meet:team' }
   ]);
 });
 


### PR DESCRIPTION
Following up on the code health improvement:
- Exported `normalizeTag` from `snippet-domain.js` so it's accessible to `popup.js`.
- Updated `popup.js` to use the shared `normalizeTag` logic when saving and editing snippets.
- This ensures that tags created or edited via the UI are standardized immediately (trimmed, default category 'general', and lowercase key generated) using the same logic as imports and filtering.
- Verified with unit tests and Playwright screenshots.

---
*PR created automatically by Jules for task [7049642967986679423](https://jules.google.com/task/7049642967986679423) started by @sugurukawamura*